### PR TITLE
Added Support for onChange when not in view

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,9 +70,9 @@ const VisibilitySensor: React.FC<Props> = (props) => {
     if (lastValue !== isVisible) {
       setLastValue(isVisible);
       props.onChange(isVisible);
-    }else{
+    } else {
       props.onChange(isVisible);
-     }
+    }
   };
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,9 @@ const VisibilitySensor: React.FC<Props> = (props) => {
     if (lastValue !== isVisible) {
       setLastValue(isVisible);
       props.onChange(isVisible);
-    }
+    }else{
+      props.onChange(isVisible);
+     }
   };
 
   return (


### PR DESCRIPTION
Earlier it was working fine if isVisible was true and doing the desired actions but if the component goes out of the view area (isVisible == false) it wasn’t triggering the action ( not returning the false value in onChange). So I added another condition that it will still send the isVisible boolean in props onChange even if it is not in the view area. Useful when you want to pause a video when not in user view.

Now you can trigger any action if not in area